### PR TITLE
Refresh homepage & contact page UI; unify styles, fix assets and mobile nav

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,8 +1,22 @@
-<!doctype html><meta charset="utf-8">
-<title>Page not found – MTC Cyber</title>
-<link rel="stylesheet" href="style.css?v=4">
-<section class="container" style="padding:64px 20px;text-align:center">
-  <h1>404</h1>
-  <p>That page doesn’t exist.</p>
-  <p><a class="btn" href="/">Go home</a></p>
-</section>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Page not found — MTC Cyber</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="mtc-style.css" />
+    <link rel="icon" type="image/png" href="mtc-logo.png" />
+  </head>
+  <body>
+    <main class="simple-page">
+      <section class="container">
+        <div class="highlight-card">
+          <p class="eyebrow">404</p>
+          <h1>Page not found</h1>
+          <p>That page does not exist or may have moved.</p>
+          <a class="btn btn-primary" href="index.html">Go home</a>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/about.html
+++ b/about.html
@@ -33,6 +33,7 @@
           class="nav-toggle"
           id="nav-toggle"
           aria-label="Toggle navigation"
+          aria-expanded="false"
         >
           <span></span><span></span><span></span>
         </button>
@@ -189,7 +190,7 @@
           <span>ABN: 37 347 798 045</span>
         </div>
       </div>
-      <script src="scripts.js"></script>
+      <script src="script.js"></script>
     </footer>
   </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -33,6 +33,7 @@
           class="nav-toggle"
           id="nav-toggle"
           aria-label="Toggle navigation"
+          aria-expanded="false"
         >
           <span></span><span></span><span></span>
         </button>
@@ -129,7 +130,7 @@
           <span>ABN: 37 347 798 045</span>
         </div>
       </div>
-      <script src="scripts.js"></script>
+      <script src="script.js"></script>
     </footer>
   </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -2,139 +2,235 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <title>Contact — MTC Cyber</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Contact MTC Cyber to request a Cyber Readiness Snapshot or discuss practical cyber security support for your Australian small business."
+    />
     <link rel="stylesheet" href="mtc-style.css" />
-
-    <title>Contact – MTC Cyber</title>
-    <link rel="stylesheet" href="style.css?v=6" />
+    <link rel="icon" type="image/png" href="mtc-logo.png" />
   </head>
   <body>
-    <header class="topbar">
-      <div class="container row space">
-        <a class="logo" href="/"
-          ><img src="mtc-logo.png" class="logo-img" alt="MTC Cyber logo"
-        /></a>
-        <nav><a href="/">Home</a></nav>
+    <header class="site-header">
+      <div class="container header-inner">
+        <a href="index.html" class="logo">
+          <img src="mtc-logo.png" alt="MTC Cyber logo" class="logo-img" />
+          <span class="logo-text">MTC Cyber</span>
+        </a>
+        <nav class="main-nav" id="main-nav">
+          <a href="index.html">Home</a>
+          <a href="services.html">Services</a>
+          <a href="about.html">About</a>
+          <a href="blog.html">Insights</a>
+          <a href="contact.html" class="active">Contact</a>
+        </nav>
+        <button
+          class="nav-toggle"
+          id="nav-toggle"
+          aria-label="Toggle navigation"
+          aria-expanded="false"
+        >
+          <span></span><span></span><span></span>
+        </button>
       </div>
     </header>
 
-    <section class="container" style="padding: 80px 20px">
-      <h1>Contact MTC Cyber</h1>
-      <p>
-        Have questions about your Cyber Readiness Snapshot or want to discuss
-        security improvements? Get in touch below.
-      </p>
-
-      <div style="margin-bottom: 24px">
-        <p>
-          <strong>Email:</strong>
-          <a href="mailto:mtccyber.au@gmail.com">mtccyber.au@gmail.com</a>
-        </p>
-        <p><strong>Phone:</strong> 0405 827 784</p>
-        <p><strong>Location:</strong> Wallan, Victoria, Australia</p>
-      </div>
-
-      <!-- improved Formspree form -->
-      <form
-        class="contact"
-        id="snapshot-form"
-        action="https://formspree.io/f/xeorvneb"
-        method="POST"
-      >
-        <div class="row wrap">
-          <label
-            >Your name
-            <input required type="text" name="name" placeholder="Full name" />
-          </label>
-
-          <label
-            >Business name
-            <input
-              type="text"
-              name="business"
-              placeholder="Your business or trading name"
-            />
-          </label>
-
-          <label
-            >Website (domain)
-            <input
-              required
-              type="url"
-              name="website"
-              placeholder="https://yourbusiness.com.au"
-            />
-            <small
-              >Enter the public domain you want scanned (we only run
-              non-intrusive public checks).</small
-            >
-          </label>
-
-          <label
-            >Email
-            <input
-              required
-              type="email"
-              name="email"
-              placeholder="you@yourbusiness.com.au"
-            />
-          </label>
-
-          <label
-            >Phone
-            <input
-              type="tel"
-              name="phone"
-              placeholder="Optional — e.g. 0405 827 784"
-            />
-          </label>
-
-          <label
-            >I'm interested in
-            <select name="service" required>
-              <option value="">Select...</option>
-              <option value="snapshot">Free Cyber Readiness Snapshot</option>
-              <option value="review">Small Business Security Review</option>
-              <option value="support">Ongoing support / advisory</option>
-              <option value="other">General question</option>
-            </select>
-          </label>
-
-          <label
-            >Message
-            <textarea
-              name="message"
-              rows="5"
-              placeholder="Any additional details (optional)"
-            ></textarea>
-          </label>
+    <main>
+      <section class="page-hero contact-hero">
+        <div class="container two-col contact-intro">
+          <div>
+            <p class="eyebrow">Request a snapshot</p>
+            <h1>Let’s make your cyber risks clear and manageable.</h1>
+            <p>
+              Tell us a little about your business and the public website you
+              want reviewed. We will confirm authorisation before running any
+              public-only checks.
+            </p>
+          </div>
+          <aside class="highlight-card contact-card">
+            <h2>Prefer to talk first?</h2>
+            <p>
+              Email, call or use the form below. You will get practical guidance
+              without pressure or enterprise jargon.
+            </p>
+            <ul class="contact-list">
+              <li>
+                <span>Email</span>
+                <a href="mailto:mtccyber.au@gmail.com">mtccyber.au@gmail.com</a>
+              </li>
+              <li>
+                <span>Phone</span>
+                <a href="tel:+61405827784">0405 827 784</a>
+              </li>
+              <li>
+                <span>Location</span>
+                Wallan, Victoria, Australia
+              </li>
+            </ul>
+          </aside>
         </div>
+      </section>
 
-        <label class="checkbox">
-          <input required type="checkbox" name="authorised" />
-          I confirm I am authorised to request a scan for the domain listed
-          above.
-        </label>
+      <section class="section">
+        <div class="container contact-grid">
+          <div class="highlight-card">
+            <h2>What happens next?</h2>
+            <ul class="check-list">
+              <li>We review your request and confirm you are authorised.</li>
+              <li>We run non-intrusive checks against public-facing services.</li>
+              <li>You receive a simple report with risks and recommended fixes.</li>
+            </ul>
+            <p>
+              No logins, no customer data access and no disruptive testing —
+              just a practical starting point for improving your security.
+            </p>
+          </div>
 
-        <label class="checkbox">
-          <input required type="checkbox" name="consent" />
-          I agree to be contacted about this request and accept the
-          <a href="privacy.html">privacy policy</a>.
-        </label>
+          <form
+            class="contact form-card dark-form"
+            id="snapshot-form"
+            action="https://formspree.io/f/xeorvneb"
+            method="POST"
+          >
+            <h2>Send a message</h2>
+            <p>
+              Fields marked with an asterisk are required so we can respond and
+              confirm the scope of your request.
+            </p>
 
-        <button class="btn xl" type="submit">Send Message</button>
-      </form>
+            <div class="row wrap">
+              <label>
+                Your name <span class="required">*</span>
+                <input required type="text" name="name" placeholder="Full name" />
+              </label>
+
+              <label>
+                Business name
+                <input
+                  type="text"
+                  name="business"
+                  placeholder="Your business or trading name"
+                />
+              </label>
+
+              <label>
+                Website (domain) <span class="required">*</span>
+                <input
+                  required
+                  type="url"
+                  name="website"
+                  placeholder="https://yourbusiness.com.au"
+                />
+                <small>
+                  Enter the public domain you want scanned. We only run
+                  non-intrusive public checks.
+                </small>
+              </label>
+
+              <label>
+                Email <span class="required">*</span>
+                <input
+                  required
+                  type="email"
+                  name="email"
+                  placeholder="you@yourbusiness.com.au"
+                />
+              </label>
+
+              <label>
+                Phone
+                <input
+                  type="tel"
+                  name="phone"
+                  placeholder="Optional — e.g. 0405 827 784"
+                />
+              </label>
+
+              <label>
+                I'm interested in <span class="required">*</span>
+                <select name="service" required>
+                  <option value="">Select...</option>
+                  <option value="snapshot">Free Cyber Readiness Snapshot</option>
+                  <option value="review">Small Business Security Review</option>
+                  <option value="support">Ongoing support / advisory</option>
+                  <option value="other">General question</option>
+                </select>
+              </label>
+
+              <label class="full-width">
+                Message
+                <textarea
+                  name="message"
+                  rows="5"
+                  placeholder="Any additional details (optional)"
+                ></textarea>
+              </label>
+            </div>
+
+            <label class="checkbox">
+              <input required type="checkbox" name="authorised" />
+              <span>
+                I confirm I am authorised to request a scan for the domain
+                listed above.
+              </span>
+            </label>
+
+            <label class="checkbox">
+              <input required type="checkbox" name="consent" />
+              <span>
+                I agree to be contacted about this request and accept the
+                <a href="privacy.html">privacy policy</a>.
+              </span>
+            </label>
+
+            <button class="btn btn-primary btn-lg" type="submit">
+              Send message
+            </button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <div class="footer-col">
+          <div class="footer-logo">
+            <span class="logo-text">MTC Cyber</span>
+          </div>
+          <p class="footer-text">
+            Practical cyber security support for Australian small businesses.
+          </p>
+        </div>
+        <div class="footer-col">
+          <h4>Contact</h4>
+          <p>
+            Email:
+            <a href="mailto:mtccyber.au@gmail.com">mtccyber.au@gmail.com</a>
+          </p>
+          <p>Phone: <a href="tel:+61405827784">0405 827 784</a></p>
+          <p>Location: Wallan, Victoria, Australia</p>
+        </div>
+        <div class="footer-col">
+          <h4>Links</h4>
+          <ul class="footer-links">
+            <li><a href="services.html">Services</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="blog.html">Insights</a></li>
+            <li><a href="privacy.html">Privacy</a></li>
+          </ul>
+        </div>
       </div>
-    </section>
-
-    <footer class="footer">
-      <div class="container row space wrap">
-        <p>© <span id="y"></span> MTC Cyber — ABN 37 347 798 045</p>
-        <p><a href="/">Home</a> · <a href="privacy.html">Privacy</a></p>
+      <div class="footer-bottom">
+        <div class="container footer-bottom-inner">
+          <span>
+            &copy; <span id="year"></span> MTC Cyber. All rights reserved.
+          </span>
+          <span>ABN: 37 347 798 045</span>
+        </div>
       </div>
     </footer>
 
-    <script>
-      document.getElementById('y').textContent = new Date().getFullYear();
-    </script>
+    <script src="script.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
           <span class="logo-text">MTC Cyber</span>
         </a>
         <nav class="main-nav" id="main-nav">
-          <a href="index.html">Home</a>
+          <a href="index.html" class="active">Home</a>
           <a href="services.html">Services</a>
           <a href="about.html">About</a>
           <a href="blog.html">Insights</a>
@@ -36,6 +36,7 @@
           class="nav-toggle"
           id="nav-toggle"
           aria-label="Toggle navigation"
+          aria-expanded="false"
         >
           <span></span><span></span><span></span>
         </button>
@@ -47,13 +48,14 @@
       <section class="hero">
         <div class="container hero-inner">
           <div class="hero-text">
+            <p class="eyebrow">Small-business cyber security • Wallan VIC</p>
             <h1>
-              Simple, practical cyber security for Australian small business.
+              Know your cyber risks before attackers do.
             </h1>
             <p>
               Get a <strong>plain-English Cyber Readiness Snapshot</strong> of
               your website and systems — no jargon, no scare tactics, just clear
-              risks and practical fixes you can act on.
+              priorities and practical fixes you can act on.
             </p>
             <div class="hero-cta">
               <a href="contact.html#snapshot-form" class="btn btn-primary"
@@ -68,19 +70,35 @@
               >
               <span>✔ Based in Wallan, Victoria</span>
             </div>
-          </div>
-          <div class="hero-card">
-            <!-- big logo added -->
-            <img
-              src="mtc-logo.png"
-              alt="MTC Cyber logo"
-              class="hero-logo-big"
-            />
-            <div class="score-badge">
-              <span class="score-label">Example score</span>
-              <span class="score-value">63 / 100</span>
-              <span class="score-sub">Moderate risk</span>
+            <div class="hero-stats" aria-label="Service highlights">
+              <div>
+                <strong>100%</strong>
+                <span>public-only checks</span>
+              </div>
+              <div>
+                <strong>PDF</strong>
+                <span>plain-English report</span>
+              </div>
+              <div>
+                <strong>Local</strong>
+                <span>Australian support</span>
+              </div>
             </div>
+          </div>
+          <div class="hero-card" aria-label="Example Cyber Readiness Snapshot">
+            <div class="hero-card-top">
+              <img
+                src="mtc-logo.png"
+                alt="MTC Cyber logo"
+                class="hero-logo-big"
+              />
+              <div class="score-badge">
+                <span class="score-label">Example score</span>
+                <span class="score-value">63 / 100</span>
+                <span class="score-sub">Moderate risk</span>
+              </div>
+            </div>
+            <div class="scan-line"><span></span></div>
             <ul class="hero-list">
               <li>
                 <strong>Missing security headers</strong> &mdash; higher risk of
@@ -136,8 +154,8 @@
               <h3>You receive a clear report</h3>
               <p>
                 Within a short timeframe, you receive a PDF snapshot with a
-                score out of 100, with risks and practical next steps
-                you can share with your IT support.
+                score out of 100, risks and practical next steps you can share
+                with your IT support.
               </p>
             </article>
           </div>
@@ -272,7 +290,7 @@
                 our IT provider to fix. It felt like a safety check rather than
                 a sales pitch.”
               </p>
-              <p class="testimonial-meta">Theo, Caldern.org</p>
+              <p class="testimonial-meta">Theo, Calder region business</p>
             </article>
             <article class="testimonial-card">
               <p class="testimonial-text">
@@ -286,7 +304,7 @@
                 “Matthew explained cyber risks in a way the whole team
                 understood. It was practical, not overwhelming.”
               </p>
-              <p class="testimonial-meta">Manager, sart up "Clear-Head</p>
+              <p class="testimonial-meta">Manager, start-up "Clear-Head"</p>
             </article>
           </div>
         </div>
@@ -458,7 +476,7 @@
           }
         }
       </script>
-      <script src="scripts.js"></script>
+      <script src="script.js"></script>
     </footer>
   </body>
 </html>

--- a/mtc-style.css
+++ b/mtc-style.css
@@ -797,3 +797,494 @@ label.checkbox {
     grid-template-columns: 1fr !important;
   }
 }
+
+/* Visual refresh and missing shared components */
+body {
+  background:
+    radial-gradient(circle at 15% 0%, rgba(14, 165, 233, 0.18), transparent 32rem),
+    radial-gradient(circle at 85% 10%, rgba(34, 211, 238, 0.12), transparent 28rem),
+    linear-gradient(180deg, #020617 0%, #07111f 52%, #020617 100%);
+}
+
+.site-header {
+  background: rgba(2, 6, 23, 0.84);
+  box-shadow: 0 12px 35px rgba(2, 6, 23, 0.28);
+}
+
+.logo:hover .logo-text {
+  color: #e0f2fe;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0 0 0.85rem;
+  color: #bae6fd;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.eyebrow::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 24px rgba(56, 189, 248, 0.9);
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 5.25rem 0 3.75rem;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: auto -8rem -12rem;
+  height: 18rem;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.16), transparent 62%);
+  pointer-events: none;
+}
+
+.hero-text h1 {
+  max-width: 12ch;
+  font-size: clamp(2.5rem, 6vw, 5.25rem);
+  line-height: 0.98;
+  letter-spacing: -0.075em;
+  background: linear-gradient(135deg, #ffffff 0%, #dbeafe 45%, #7dd3fc 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.hero-text p {
+  max-width: 39rem;
+  font-size: 1.08rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 2.75rem;
+  padding: 0.76rem 1.05rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  font-size: 0.92rem;
+  line-height: 1.1;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease,
+    background 0.18s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.btn-primary {
+  color: #00111f;
+  background: linear-gradient(135deg, #67e8f9 0%, #38bdf8 45%, #0ea5e9 100%);
+  box-shadow: 0 16px 42px rgba(14, 165, 233, 0.32);
+}
+
+.btn-primary:hover {
+  color: #00111f;
+  box-shadow: 0 20px 54px rgba(14, 165, 233, 0.42);
+}
+
+.btn-secondary,
+.btn-outline {
+  color: #e0f2fe;
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(125, 211, 252, 0.38);
+}
+
+.btn-secondary:hover,
+.btn-outline:hover {
+  color: #ffffff;
+  border-color: rgba(125, 211, 252, 0.75);
+  background: rgba(14, 165, 233, 0.13);
+}
+
+.btn-lg {
+  min-height: 3rem;
+  padding-inline: 1.35rem;
+}
+
+.link-arrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 700;
+}
+
+.link-arrow::after {
+  content: '→';
+  transition: transform 0.18s ease;
+}
+
+.link-arrow:hover::after {
+  transform: translateX(3px);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  max-width: 38rem;
+  margin-top: 1.6rem;
+}
+
+.hero-stats div {
+  padding: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.66);
+}
+
+.hero-stats strong,
+.hero-stats span {
+  display: block;
+}
+
+.hero-stats strong {
+  color: #e0f2fe;
+  font-size: 1.05rem;
+}
+
+.hero-stats span {
+  margin-top: 0.2rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.hero-card {
+  padding: 1.55rem;
+  background:
+    linear-gradient(145deg, rgba(15, 23, 42, 0.96), rgba(2, 6, 23, 0.96)),
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.24), transparent 45%);
+  box-shadow: 0 30px 80px rgba(2, 6, 23, 0.68), inset 0 1px 0 rgba(255,255,255,0.06);
+}
+
+.hero-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hero-card .hero-logo-big,
+.hero-logo-big {
+  width: 84px;
+  max-width: 84px;
+  margin: 0;
+  border-radius: 22px;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  box-shadow: 0 18px 46px rgba(2, 6, 23, 0.45);
+}
+
+.scan-line {
+  height: 0.55rem;
+  margin: 1.35rem 0 0.45rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.scan-line span {
+  display: block;
+  width: 63%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--danger), #f59e0b, var(--accent));
+}
+
+.hero-list {
+  padding-left: 0;
+  list-style: none;
+}
+
+.hero-list li {
+  padding: 0.85rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.hero-list li::before {
+  content: '▹';
+  margin-right: 0.4rem;
+  color: var(--accent);
+}
+
+.step-card,
+.pricing-card,
+.highlight-card,
+.testimonial-card,
+.blog-card,
+.value-card,
+.faq-item,
+.profile-card {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.78));
+  box-shadow: 0 18px 50px rgba(2, 6, 23, 0.28);
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.step-card:hover,
+.pricing-card:hover,
+.testimonial-card:hover,
+.blog-card:hover,
+.value-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.44);
+  box-shadow: 0 24px 62px rgba(2, 6, 23, 0.42);
+}
+
+.section-alt {
+  background: rgba(2, 6, 23, 0.38);
+}
+
+.cta-section,
+.cta-inner {
+  position: relative;
+}
+
+.cta-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(125, 211, 252, 0.3);
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(circle at right, rgba(14, 165, 233, 0.24), transparent 22rem),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.98), rgba(8, 47, 73, 0.72));
+  box-shadow: var(--shadow-soft);
+}
+
+.cta-inner p {
+  margin-bottom: 0;
+}
+
+.site-footer {
+  margin-top: auto;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.92);
+}
+
+.footer-inner {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 0.8fr;
+  gap: 2rem;
+  padding: 2.4rem 1.5rem;
+}
+
+.footer-col h4 {
+  margin-bottom: 0.65rem;
+}
+
+.footer-text,
+.footer-col p {
+  margin: 0 0 0.55rem;
+  font-size: 0.9rem;
+}
+
+.footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.footer-links li {
+  margin-bottom: 0.4rem;
+}
+
+.footer-bottom {
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.footer-bottom-inner {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.9rem;
+  padding-bottom: 0.9rem;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.contact-hero {
+  padding-top: 4rem;
+}
+
+.contact-intro {
+  align-items: center;
+}
+
+.contact-intro h1 {
+  max-width: 12ch;
+  font-size: clamp(2.4rem, 5vw, 4.35rem);
+  line-height: 1;
+}
+
+.contact-card h2,
+.dark-form h2 {
+  font-size: 1.25rem;
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+
+.contact-list li {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--text-muted);
+}
+
+.contact-list span {
+  color: #bae6fd;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.form-card.dark-form {
+  margin: 0;
+  max-width: none;
+  color: var(--text);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(15, 23, 42, 0.84));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-soft);
+}
+
+.contact label {
+  color: #e5e7eb;
+  font-weight: 600;
+}
+
+.contact .full-width {
+  flex-basis: 100%;
+}
+
+.contact input[type='text'],
+.contact input[type='email'],
+.contact input[type='url'],
+.contact input[type='tel'],
+.contact select,
+.contact textarea,
+input[type='text'],
+input[type='email'],
+textarea {
+  color: var(--text);
+  background: rgba(2, 6, 23, 0.72);
+  border-color: rgba(148, 163, 184, 0.34);
+}
+
+.contact input::placeholder,
+.contact textarea::placeholder {
+  color: rgba(156, 163, 175, 0.72);
+}
+
+.contact select option {
+  color: #111827;
+}
+
+label.checkbox {
+  flex-direction: row;
+  align-items: flex-start;
+  color: var(--text-muted);
+}
+
+label.checkbox input {
+  margin-top: 0.18rem;
+  accent-color: var(--accent-strong);
+}
+
+.simple-page {
+  min-height: 70vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+
+.simple-page .highlight-card {
+  max-width: 38rem;
+}
+
+@media (max-width: 860px) {
+  .main-nav {
+    position: absolute;
+    top: 100%;
+    left: 1rem;
+    right: 1rem;
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.25rem;
+    padding: 0.85rem;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: 20px;
+    background: rgba(2, 6, 23, 0.98);
+    box-shadow: var(--shadow-soft);
+  }
+
+  .main-nav.open {
+    display: flex;
+  }
+
+  .main-nav a {
+    padding: 0.75rem 0.85rem;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .hero {
+    padding-top: 3.5rem;
+  }
+
+  .hero-stats,
+  .footer-inner {
+    grid-template-columns: 1fr;
+  }
+
+  .cta-inner,
+  .footer-bottom-inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 560px) {
+  .container {
+    padding-inline: 1rem;
+  }
+
+  .hero-text h1,
+  .contact-intro h1 {
+    font-size: 2.55rem;
+  }
+
+  .hero-card-top {
+    flex-direction: column;
+  }
+
+  .score-badge {
+    width: 100%;
+  }
+}

--- a/privacy.html
+++ b/privacy.html
@@ -16,7 +16,7 @@
       <div class="container header-inner">
         <a href="index.html" class="logo">
           <img
-            src="images/mtc-logo.png"
+            src="mtc-logo.png"
             alt="MTC Cyber logo"
             class="logo-img"
           />
@@ -33,6 +33,7 @@
           class="nav-toggle"
           id="nav-toggle"
           aria-label="Toggle navigation"
+          aria-expanded="false"
         >
           <span></span><span></span><span></span>
         </button>
@@ -142,7 +143,7 @@
           <span>ABN: 37 347 798 045</span>
         </div>
       </div>
-      <script src="scripts.js"></script>
+      <script src="script.js"></script>
     </footer>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -4,11 +4,19 @@ const mainNav = document.getElementById('main-nav');
 
 if (navToggle && mainNav) {
   navToggle.addEventListener('click', () => {
-    mainNav.classList.toggle('open');
+    const isOpen = mainNav.classList.toggle('open');
+    navToggle.setAttribute('aria-expanded', String(isOpen));
+  });
+
+  mainNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      mainNav.classList.remove('open');
+      navToggle.setAttribute('aria-expanded', 'false');
+    });
   });
 }
 
-// Smooth scroll for in-page links (like "How it works")
+// Smooth scroll for same-page links (like "How it works")
 document.querySelectorAll('a[href^="#"]').forEach((link) => {
   link.addEventListener('click', (evt) => {
     const targetId = link.getAttribute('href').slice(1);

--- a/services.html
+++ b/services.html
@@ -9,7 +9,7 @@
       content="See MTC Cyber's cyber security services for Australian small businesses, including Cyber Readiness Snapshot and deeper reviews."
     />
     <link rel="stylesheet" href="mtc-style.css" />
-    <link rel="icon" type="image/png" href="images/mtc-logo.png" />
+    <link rel="icon" type="image/png" href="mtc-logo.png" />
   </head>
   <body>
     <header class="site-header">
@@ -33,6 +33,7 @@
           class="nav-toggle"
           id="nav-toggle"
           aria-label="Toggle navigation"
+          aria-expanded="false"
         >
           <span></span><span></span><span></span>
         </button>
@@ -198,7 +199,7 @@
           <span>ABN: 37 347 798 045</span>
         </div>
       </div>
-      <script src="scripts.js"></script>
+      <script src="script.js"></script>
     </footer>
   </body>
 </html>

--- a/thanks.html
+++ b/thanks.html
@@ -1,8 +1,22 @@
-<!doctype html><meta charset="utf-8">
-<title>Thanks – MTC Cyber</title>
-<link rel="stylesheet" href="style.css?v=4">
-<section class="container" style="padding:64px 20px">
-  <h1>Thanks! 🎉</h1>
-  <p>We’ve received your request. We’ll email your snapshot within one business day.</p>
-  <p><a class="btn" href="/">Back to home</a></p>
-</section>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Thanks — MTC Cyber</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="mtc-style.css" />
+    <link rel="icon" type="image/png" href="mtc-logo.png" />
+  </head>
+  <body>
+    <main class="simple-page">
+      <section class="container">
+        <div class="highlight-card">
+          <p class="eyebrow">Request received</p>
+          <h1>Thanks! 🎉</h1>
+          <p>We have received your request and will email you about next steps.</p>
+          <a class="btn btn-primary" href="index.html">Back to home</a>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Improve the visual appeal and clarity of the homepage hero so visitors immediately understand the offering and CTA. 
- Replace inconsistent page fragments with a shared header/footer and stylesheet to ensure consistent branding and responsive behaviour. 
- Make the contact flow clearer and easier to use for small businesses, and fix broken asset/script references that caused flaky page behaviour.

### Description
- Updated the homepage (`index.html`) hero copy and structure, added an `eyebrow` line, `hero-stats` highlights, and reworked the example snapshot card markup (scan progress line and compact logo/score layout). 
- Rebuilt the contact page (`contact.html`) to use the shared site `header`/`footer`, a two-column intro, a dark-themed responsive `form-card` and clearer “what happens next” content. 
- Large visual refresh in `mtc-style.css` adding hero typography, button styles (`.btn`, `.btn-primary`, `.btn-secondary`), card hover states, CTA layout (`.cta-inner`), footer layout, contact styles, mobile nav rules and small utility components (`.eyebrow`, `.scan-line`, `.hero-stats`). 
- Fixed scripting and asset issues by replacing references to `scripts.js`/missing image paths with `script.js` and `mtc-logo.png`, added a new `script.js` that improves mobile nav toggle behaviour (sets `aria-expanded` and closes the menu when a nav link is clicked). 
- Reworked the simple pages (`404.html` and `thanks.html`) to use the shared stylesheet and consistent card/button treatments for a polished fallback experience.

### Testing
- Parsed every HTML file with Python `html.parser` to validate well-formed markup, which succeeded. 
- Ran a local href/src check via a Python script to confirm all local `href`/`src` targets exist, which reported no missing assets. 
- Ran `git diff --check` and verified there were no check failures, and served the site locally with `python3 -m http.server` then confirmed key endpoints responded with HTTP 200 via `curl -I`, all of which succeeded. 
- Attempted automated screenshot capture via `playwright` but installation was blocked by the registry returning `403 Forbidden`, so browser screenshots were not captured (non-blocking warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0adb509f3c83318c23bb366ef8cfec)